### PR TITLE
Modify setup.py to open README.rst as utf-8 file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 from iapws import __version__
 
 
-with open('README.rst') as file:
+with open('README.rst', encoding="utf8") as file:
     long_description = file.read()
 
 setup(
@@ -30,5 +30,5 @@ setup(
         "Topic :: Scientific/Engineering :: Chemistry",
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Software Development :: Libraries :: Python Modules"
-        ]
-    )
+    ]
+)


### PR DESCRIPTION
I was getting the following error when trying to install with Python 3.4.3 on Arch Linux.

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1141: ordinal not in range(128)
```

This change fixed the problem.