### PR TITLE
Backwards compatibility with Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@ from setuptools import setup
 
 from iapws import __version__
 
+import io # for backwards compatibility with Python 2
 
-with open('README.rst', encoding="utf8") as file:
+
+with io.open('README.rst', encoding="utf8") as file:
     long_description = file.read()
 
 setup(


### PR DESCRIPTION
Currently, one can only install this package using Python 3, as Python 2's `open()` function doesn' have an `encoding` parameter. This can be solved by using `io.open`, which is Python 3's new `open` function.
It's available since Python 2.6. It's implemented in Python in 2.6 and 3.0, which makes it kinda slow, but that shouldn't be a problem in this case.