### PR TITLE
minimize initial guess is actual midpoint

### DIFF
--- a/iapws/_iapws.py
+++ b/iapws/_iapws.py
@@ -513,7 +513,7 @@ def _Supercooled(T, P):
     def f(x):
         return abs(L+log(x/(1-x))+omega*(1-2*x))
 
-    x = minimize(f, ((xmin+xmax)/2,), bounds=((xmin, xmax),))["x"][0]
+    x = minimize(f, (xmin+((xmin+xmax)/2),), bounds=((xmin, xmax),))["x"][0]
 
     # Eq 12
     fi = 2*x-1


### PR DESCRIPTION
this "bug" might be insignificant in that the midpoint created by `(xmin+xmax)/2` won't be particularly far from `xmin+((xmin+xmax)/2)`, but 1. the latter more correctly communicates intent and 2. is correct even for relatively high values of xmin. (This is assuming I'm correctly interpreting the intent/function of the original line of code- am I correct here?)