### PR TITLE
Clarify units of HR

### DIFF
--- a/iapws/humidAir.py
+++ b/iapws/humidAir.py
@@ -567,7 +567,7 @@ class HumidAir(object):
         * mu: Relative chemical potential, [kJ/kg]
         * muw: Chemical potential of water, [kJ/kg]
         * M: Molar mass of humid air, [g/mol]
-        * HR: Humidity ratio, [-]
+        * HR: Humidity ratio, Mass fraction of water in dry air, [kg/kg]
         * RH: Relative humidity, [-]
     """
 


### PR DESCRIPTION
Definitions, names may change from place to place, HR is not always what is here, short description will be helpful.
As further improvement, I would suggest to be able to describe HumidAir with HR as an alternative to A, W, xa, xw (in my experience in industry, HR is much much more used than A or W. HR is just W/(1-W)).