### PR TITLE
Update HumidAir object documentation

### DIFF
--- a/iapws/humidAir.py
+++ b/iapws/humidAir.py
@@ -540,7 +540,7 @@ class HumidAir(object):
     -----
     * It needs two incoming properties of T, P, rho.
     * v as a alternate input parameter to rho
-    * For composition need one of A, xa, W, xw.
+    * For composition need one of A, xa, W, xw, HR.
 
     The calculated instance has the following properties:
 


### PR DESCRIPTION
Just a very small change because I found this confusing while reading the docs! - HR can be used as a composition parameter. This update fixed the documentation to reflect that.