### PR TITLE
Update for numpy 2.4 compatability

### DIFF
--- a/iapws/_iapws.py
+++ b/iapws/_iapws.py
@@ -33,7 +33,12 @@ Miscelaneous IAPWS standards. This module include:
 from __future__ import division
 
 from cmath import log as log_c
-from math import log, exp, tan, atan, acos, sin, pi, log10
+from numpy import log, exp, tan, sin, pi, log10
+try:
+    from numpy import acos, atan
+except ImportError:
+    from math import acos, atan
+
 import warnings
 
 from scipy.optimize import newton

--- a/iapws/ammonia.py
+++ b/iapws/ammonia.py
@@ -14,7 +14,7 @@ include:
 
 
 from __future__ import division
-from math import exp, log, pi
+from numpy import exp, log, pi
 import warnings
 
 from scipy.constants import Boltzmann

--- a/iapws/humidAir.py
+++ b/iapws/humidAir.py
@@ -18,7 +18,12 @@ include:
 
 
 from __future__ import division
-from math import exp, log, pi, atan
+from numpy import exp, log, pi
+try:
+    from numpy import atan
+except ImportError:
+    from math import atan
+    
 import warnings
 
 from scipy.optimize import fsolve

--- a/iapws/humidAir.py
+++ b/iapws/humidAir.py
@@ -23,7 +23,7 @@ try:
     from numpy import atan
 except ImportError:
     from math import atan
-    
+
 import warnings
 
 from scipy.optimize import fsolve

--- a/iapws/iapws08.py
+++ b/iapws/iapws08.py
@@ -508,7 +508,7 @@ def _Tf(P, S):
     Properties of Seawater, http://www.iapws.org/relguide/Advise5.html, Eq 12
     """
     def f(T):
-        T = T.item()
+        T = float(T.item())
         pw = _Region1(T, P)
         gw = pw["h"]-T*pw["s"]
 

--- a/iapws/iapws08.py
+++ b/iapws/iapws08.py
@@ -23,7 +23,7 @@ Other functionality:
 """
 
 from __future__ import division
-from math import exp, log
+from numpy import exp, log
 import warnings
 
 from scipy.optimize import fsolve
@@ -508,7 +508,7 @@ def _Tf(P, S):
     Properties of Seawater, http://www.iapws.org/relguide/Advise5.html, Eq 12
     """
     def f(T):
-        T = float(T)
+        T = T.item()
         pw = _Region1(T, P)
         gw = pw["h"]-T*pw["s"]
 

--- a/iapws/iapws97.py
+++ b/iapws/iapws97.py
@@ -87,7 +87,7 @@ doi: 10.1007/978-3-540-74234-0
 """
 
 from __future__ import division
-from math import sqrt, log, exp
+from numpy import sqrt, log, exp
 from scipy.optimize import fsolve, newton
 import numpy as np
 


### PR DESCRIPTION
Addresses iss #80
v1.5.4 (and code on master) fails with numpy 2.4.3 due to removal of numpy aliases from scipy and stricter scalar conversion in numpy.

To correct, math functions (e.g. log, acos, etc) now imported from numpy for compatability with numpy 2.4.  Also, retained compatability with older versions of numpy by adding try/except for acos, atan imports with ImportError exception handler reverting back to from "math import acos, atan" as these functions were not in older version of numpy.   

Test cases were successful with:  
numpy 1.26.4  
=========================== 45 passed, 36 warnings in 4.73s ===========================   
numpy 2.4.3  
=========================== 45 passed, 36 warnings in 4.92s ===========================  

Noted here too - https://bbs.archlinux.org/viewtopic.php?id=312242#:~:text=Note%20test%20will%20fail%20as,7%20@@%20Miscelaneous%20IAPWS%20standards.